### PR TITLE
Migrate from OSSRH to Maven Central Repository publishing

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -37,14 +37,14 @@ jobs:
       - name: Publish to Maven Central Repository
         run: mvn deploy --batch-mode --activate-profiles release --no-transfer-progress --file ironpdf/pom.xml
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME2 }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD2 }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish Cloud to Maven Central Repository
         run: mvn deploy -Dmaven.test.skip=true --batch-mode --activate-profiles release --no-transfer-progress --file ironpdf-cloud/pom.xml
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME2 }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD2 }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}  
       - name: Upload JARs to GitHub Release
         uses: AButler/upload-release-assets@v2.0
@@ -76,7 +76,7 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -84,32 +84,32 @@ jobs:
       - name: Publish linux-x64 to Maven Central Repository
         run: mvn deploy --batch-mode --activate-profiles release --no-transfer-progress --file ironpdf-engine-pack/ironpdf-engine-linux-x64/pom.xml
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME2 }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD2 }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish windows-x64 to Maven Central Repository
         run: mvn deploy --batch-mode --activate-profiles release --no-transfer-progress --file ironpdf-engine-pack/ironpdf-engine-windows-x64/pom.xml
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME2 }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD2 }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}  
-      - name: Publish windows-x86 to Maven Central Repository   
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Publish windows-x86 to Maven Central Repository
         run: mvn deploy --batch-mode --activate-profiles release --no-transfer-progress --file ironpdf-engine-pack/ironpdf-engine-windows-x86/pom.xml
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME2 }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD2 }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish macos-arm64 to Maven Central Repository   
         run: mvn deploy --batch-mode --activate-profiles release --no-transfer-progress --file ironpdf-engine-pack/ironpdf-engine-macos-arm64/pom.xml
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME2 }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD2 }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish macos-x64 to Maven Central Repository   
         run: mvn deploy --batch-mode --activate-profiles release --no-transfer-progress --file ironpdf-engine-pack/ironpdf-engine-macos-x64/pom.xml
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME2 }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD2 }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   publish-javadoc-from-java11:
     runs-on: ubuntu-22.04
@@ -128,7 +128,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -136,8 +136,8 @@ jobs:
       - name: Build Java doc .jar
         run: mvn compile javadoc:jar -Pjavadoc-java11 --file ironpdf/pom.xml
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME2 }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD2 }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload JARs to GitHub Release
         uses: AButler/upload-release-assets@v2.0

--- a/ironpdf-engine-pack/ironpdf-engine-linux-x64/pom.xml
+++ b/ironpdf-engine-pack/ironpdf-engine-linux-x64/pom.xml
@@ -38,8 +38,8 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/api/v1/publisher/upload</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -49,14 +49,13 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>false</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/ironpdf-engine-pack/ironpdf-engine-macos-arm64/pom.xml
+++ b/ironpdf-engine-pack/ironpdf-engine-macos-arm64/pom.xml
@@ -38,8 +38,8 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/api/v1/publisher/upload</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -49,14 +49,13 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>false</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/ironpdf-engine-pack/ironpdf-engine-macos-x64/pom.xml
+++ b/ironpdf-engine-pack/ironpdf-engine-macos-x64/pom.xml
@@ -38,8 +38,8 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/api/v1/publisher/upload</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -49,14 +49,13 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>false</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/ironpdf-engine-pack/ironpdf-engine-windows-x64/pom.xml
+++ b/ironpdf-engine-pack/ironpdf-engine-windows-x64/pom.xml
@@ -38,8 +38,8 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/api/v1/publisher/upload</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -49,14 +49,13 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>false</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/ironpdf-engine-pack/ironpdf-engine-windows-x86/pom.xml
+++ b/ironpdf-engine-pack/ironpdf-engine-windows-x86/pom.xml
@@ -38,8 +38,8 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/api/v1/publisher/upload</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -49,14 +49,13 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>false</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/ironpdf/pom.xml
+++ b/ironpdf/pom.xml
@@ -36,8 +36,8 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/api/v1/publisher/upload</url>
         </snapshotRepository>
     </distributionManagement>
     <properties>
@@ -64,14 +64,13 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>false</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/ironpdf/src/main/java/com/ironsoftware/ironpdf/internal/staticapi/BuildInfo.java
+++ b/ironpdf/src/main/java/com/ironsoftware/ironpdf/internal/staticapi/BuildInfo.java
@@ -1,4 +1,4 @@
 package com.ironsoftware.ironpdf.internal.staticapi;
 class BuildInfo {
-    static final String BUILD_TIMESTAMP = "10/16/2024";
+    static final String BUILD_TIMESTAMP = "07/09/2025";
 }


### PR DESCRIPTION
## Description

This PR migrates the Maven publishing configuration from the legacy OSSRH (OSS Repository Hosting) system to Maven Central's new direct publishing API.

## Changes Made

Maven Configuration Updates:
  - Replace `nexus-staging-maven-plugin` with `central-publishing-maven-plugin` v0.8.0
  - Update repository URLs from https://s01.oss.sonatype.org/content/repositories/snapshots to https://central.sonatype.com/api/v1/publisher/upload
  - Change `server-id` from "ossrh" to "central" in all POM files
  - Configure `autoPublish`: false for manual release control

  GitHub Actions Workflow Updates:
  - Update `server-id` from "ossrh" to "central" in setup-java action
  - Replace environment variables:
    - `OSSRH_USERNAME2` → `CENTRAL_USERNAME`
    - `OSSRH_PASSWORD2` → `CENTRAL_TOKEN_PASSWORD`